### PR TITLE
Update README.md: Installation also needs resources/ folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ cd YourEmulationStationDirectory
 
 sudo mv /opt/retropie/supplementary/emulationstation/emulationstation /opt/retropie/supplementary/emulationstation/emulationstation.bak
 sudo cp emulationstation /opt/retropie/supplementary/emulationstation/
+sudo cp -r resources /opt/retropie/supplementary/emulationstation/
 sudo cp -r locale /opt/retropie/supplementary/emulationstation/
 ```
 


### PR DESCRIPTION
Seems to crash ES when installed manually and the resources/ folder is missing.

It is a known issue https://github.com/RetroPie/EmulationStation/issues/759

The scriptmodule does install it https://github.com/RetroPie/RetroPie-Setup/blob/master/scriptmodules/supplementary/emulationstation.sh#L208

PR updates this README to reflect the additional manual step.